### PR TITLE
Finix v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,10 +194,7 @@ GIDX.showApplePayButton(
                 MerchantSessionID: '1234',
                 PaymentMethod: {
                     Type: paymentMethod.Type,
-                    Token: paymentMethod.Token,
-
-                    //If using Approvley Rapid, also pass 3DS device data
-                    ThreeDS: GIDX.get3DSDeviceData()
+                    Token: paymentMethod.Token
                 }
             };
         }
@@ -296,6 +293,38 @@ By default, the Approvely Rapid 3DS challenge is an HTML5 dialog element inserte
 The [default CSS](src/lib/index.css) is included in the library, but feel free to add your own CSS to your page.
 
 For more advanced customization, you can provide `insertElement` and `removeElement` functions in your `options` object.
+
+## Plaid through Finix
+Finix provides Plaid support to allow the user to login to their bank account instead of collecting the routing and account numbers yourself. We support this through our `showPaymentMethodForm` method, by passing `ACH` in the `paymentMethodTypes` option.
+```js
+//Get the ACH Tokenizer configuration returned in the CreateSession response
+let achSettings = createSessionResponse.PaymentMethodSettings.find((s) => s.Type === "ACH");
+
+//Call the function to render the form inside of your HTML element
+GIDX.showPaymentMethodForm(
+    'id-of-html-element', //The id of the HTML element. Must already exist on the page.
+    {
+        merchantSessionId: '1234', //Must be the same MerchantSessionID provided to the CreateSession API.
+        paymentMethodTypes: ['ACH'],
+        tokenizer: achSettings.Tokenizer,
+        showSubmitButton: true, //or false if you want to manually submit yourself.
+        onSaved: function (paymentMethod) {
+            //The full PaymentMethod object returned from our API is passed to this function.
+            //Use it to populate your CompleteSession request and finalize the transaction.
+            let completeSessionRequest = {
+                MerchantSessionID: '1234',
+                PaymentMethod: {
+                    Type: paymentMethod.Type,
+                    Token: paymentMethod.Token
+                }
+            };
+        }
+    });
+```
+```
+
+### Testing Plaid on sandbox
+Use any of the banks with "Platypus" in their name along with username `user_good` and password `pass_good`. For additional testing scenarios, see [Plaid's documentation](https://plaid.com/docs/sandbox/test-credentials/).
 
 ## Processor Session ID
 Some processors, like Finix, require you to use their own JS SDK's for monitoring risk and fraud. To do this, you must call `GIDX.init` on every page of your application. Then, you must pass the `ProcessorSessionID` in your CreateSession or CompleteSession API requests.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This library includes utilities for:
 * [Credit Card Tokenization](#tokenization)
 * [Apple Pay and Google Pay](#apple-pay-and-google-pay)
 * [3DS](#3ds)
+* [Plaid through Finix](#plaid-through-finix)
 * [Processor Session ID](#processor-session-id)
 
 ## Install

--- a/doc/README.hbs
+++ b/doc/README.hbs
@@ -294,6 +294,38 @@ The [default CSS](src/lib/index.css) is included in the library, but feel free t
 
 For more advanced customization, you can provide `insertElement` and `removeElement` functions in your `options` object.
 
+## Plaid through Finix
+Finix provides Plaid support to allow the user to login to their bank account instead of collecting the routing and account numbers yourself. We support this through our `showPaymentMethodForm` method, by passing `ACH` in the `paymentMethodTypes` option.
+```js
+//Get the ACH Tokenizer configuration returned in the CreateSession response
+let achSettings = createSessionResponse.PaymentMethodSettings.find((s) => s.Type === "ACH");
+
+//Call the function to render the form inside of your HTML element
+GIDX.showPaymentMethodForm(
+    'id-of-html-element', //The id of the HTML element. Must already exist on the page.
+    {
+        merchantSessionId: '1234', //Must be the same MerchantSessionID provided to the CreateSession API.
+        paymentMethodTypes: ['ACH'],
+        tokenizer: achSettings.Tokenizer,
+        showSubmitButton: true, //or false if you want to manually submit yourself.
+        onSaved: function (paymentMethod) {
+            //The full PaymentMethod object returned from our API is passed to this function.
+            //Use it to populate your CompleteSession request and finalize the transaction.
+            let completeSessionRequest = {
+                MerchantSessionID: '1234',
+                PaymentMethod: {
+                    Type: paymentMethod.Type,
+                    Token: paymentMethod.Token
+                }
+            };
+        }
+    });
+```
+```
+
+### Testing Plaid on sandbox
+Use any of the banks with "Platypus" in their name along with username `user_good` and password `pass_good`. For additional testing scenarios, see [Plaid's documentation](https://plaid.com/docs/sandbox/test-credentials/).
+
 ## Processor Session ID
 Some processors, like Finix, require you to use their own JS SDK's for monitoring risk and fraud. To do this, you must call `GIDX.init` on every page of your application. Then, you must pass the `ProcessorSessionID` in your CreateSession or CompleteSession API requests.
 

--- a/doc/README.hbs
+++ b/doc/README.hbs
@@ -7,6 +7,7 @@ This library includes utilities for:
 * [Credit Card Tokenization](#tokenization)
 * [Apple Pay and Google Pay](#apple-pay-and-google-pay)
 * [3DS](#3ds)
+* [Plaid through Finix](#plaid-through-finix)
 * [Processor Session ID](#processor-session-id)
 
 ## Install

--- a/src/demo/index.html
+++ b/src/demo/index.html
@@ -4,7 +4,8 @@
 <head>
     <meta charset="utf-8" />
     <title>3DS Challenge Demo</title>
-    <script type="text/javascript" src="https://js.finix.com/v/1/finix.js"></script>
+    <!--<script type="text/javascript" src="https://js.finix.com/v/1/finix.js"></script>-->
+    <!--<script type="text/javascript" src="https://js.finix.com/v/2/finix.js"></script>-->
 </head>
 <body>
     <h1>3DS Challenge Demo</h1>

--- a/src/demo/index.html
+++ b/src/demo/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8" />
     <title>3DS Challenge Demo</title>
     <!--<script type="text/javascript" src="https://js.finix.com/v/1/finix.js"></script>-->
-    <!--<script type="text/javascript" src="https://js.finix.com/v/2/finix.js"></script>-->
+    <script type="text/javascript" src="https://js.finix.com/v/2/finix.js"></script>
 </head>
 <body>
     <h1>3DS Challenge Demo</h1>

--- a/src/demo/index.js
+++ b/src/demo/index.js
@@ -60,19 +60,25 @@ GIDX.init({
     }
 });
 
-let tokenizer = {
-    //type: "Finix",
-    //applicationId: "APeETPt5ca7BSf3bTQYnFr5T"
+let evervaultTokenizer = {
     type: "Evervault",
     teamId: "team_138d39e80bcb",
     appId: "app_eaa0d7860365",
     merchantId: "merchant_14d1b2bc033c"
 };
 
+let finixTokenizer = {
+    type: "Finix",
+    version: "2",
+    applicationId: "APeETPt5ca7BSf3bTQYnFr5T"
+}
+
 let form = GIDX.showPaymentMethodForm("payment-method-form", {
-    //paymentMethodTypes: ["ACH", "CC"]
+    //paymentMethodTypes: ["ACH", "CC"],
+    paymentMethodTypes: ["CC"],
     merchantSessionId: "1234",
-    tokenizer,
+    tokenizer: finixTokenizer,
+    //tokenizer: evervaultTokenizer,
     theme: "material"
 });
 
@@ -86,7 +92,7 @@ document.getElementById("get-processor-session-id").onclick = function () {
 
 GIDX.showGooglePayButton('google-pay-button', {
     merchantSessionId: "1234",
-    tokenizer,
+    tokenizer: evervaultTokenizer,
     transaction: {
         amount: 1000
     },
@@ -97,7 +103,7 @@ GIDX.showGooglePayButton('google-pay-button', {
 
 GIDX.showApplePayButton('apple-pay-button', {
     merchantSessionId: "1234",
-    tokenizer,
+    tokenizer: evervaultTokenizer,
     transaction: {
         amount: 1000
     },

--- a/src/demo/index.js
+++ b/src/demo/index.js
@@ -69,7 +69,6 @@ let evervaultTokenizer = {
 
 let finixTokenizer = {
     type: "Finix",
-    version: "2",
     applicationId: "APeETPt5ca7BSf3bTQYnFr5T"
 }
 

--- a/src/demo/index.js
+++ b/src/demo/index.js
@@ -73,12 +73,13 @@ let finixTokenizer = {
 }
 
 let form = GIDX.showPaymentMethodForm("payment-method-form", {
-    //paymentMethodTypes: ["ACH", "CC"],
-    paymentMethodTypes: ["CC"],
+    paymentMethodTypes: ["ACH"],
+    //paymentMethodTypes: ["CC"],
     merchantSessionId: "1234",
     tokenizer: finixTokenizer,
     //tokenizer: evervaultTokenizer,
-    theme: "material"
+    theme: "material",
+    showSubmitButton: true
 });
 
 //document.getElementById("save-payment-method").onclick = function () {

--- a/src/lib/processorSessionId-finix.js
+++ b/src/lib/processorSessionId-finix.js
@@ -5,11 +5,13 @@ let defaultSandboxOptions = {
     merchantId: 'MU4cihj5vQnQ1x8zxmE5jG4G' //GambleID's Finix Sandbox Merchant ID
 }
 
+//Finix API Docs: https://docs.finix.com/js/auth?__step=init
+
 class Finix {
     constructor(options) {
         var self = this;
         if (!window.Finix) {
-            loadScript('https://js.finix.com/v/1/finix.js').then(() => self.init(options));
+            loadScript('https://js.finix.com/v/2/finix.js').then(() => self.init(options));
         }
         else {
             self.init(options);

--- a/src/lib/tokenization-finix.js
+++ b/src/lib/tokenization-finix.js
@@ -6,7 +6,7 @@ import { sendPaymentMethodRequest } from './tokenization.js';
 class Finix {
     constructor(elementId, options) {
         var self = this;
-        if (!window.Finix) {
+        if (!window.Finix?.TokenForm) {
             loadScript('https://js.finix.com/v/1/finix.js').then(() => self.init(elementId, options));
         }
         else {
@@ -59,6 +59,64 @@ class Finix {
     }
 }
 
+class FinixV2 {
+    constructor(elementId, options) {
+        var self = this;
+        if (!window.Finix?.PaymentForm) {
+            //If Finix v1 exists on the page, remove it. Finix v2 won't overwrite the window.Finix variable, so we need to remove it first.
+            window.Finix = null;
+            loadScript('https://js.finix.com/v/2/finix.js').then(() => self.init(elementId, options));
+        }
+        else {
+            self.init(elementId, options);
+        }
+    }
+
+    init(elementId, options) {
+        //Passing Finix the onSubmit option will show their submit button. If showSubmitButton is false, merchant will need to manually call submit.
+        if (options.showSubmitButton) {
+            options.onSubmit = this.onSubmit.bind(this);
+        };
+
+        let finixEnvironment = gidxOptions.environment == "production" ? "prod" : "sandbox";
+
+        //Map our paymentMethodTypes (CC, ACH) to Finix's paymentMethods (card, bank)
+        if (!options.paymentMethods) {
+            options.paymentMethods = options.paymentMethodTypes.map(i => i == 'ACH' ? 'bank' : 'card');
+        }
+
+        this.finixForm = window.Finix.PaymentForm(elementId, finixEnvironment, options.tokenizer.applicationid, options);
+    }
+
+    submit() {
+        this.finixForm.submit(this.onSubmit.bind(this));
+    }
+
+    async onSubmit(err, res) {
+        let self = this;
+        let options = self.options;
+
+        if (!res.data?.id)
+            options.onError(res || err, null);
+
+        let paymentMethod = {
+            type: res.data.instrument_type == 'BANK_ACCOUNT' ? 'ACH' : 'CC',
+            processorToken: {
+                processor: 'Finix',
+                token: res.data.id
+            }
+        };
+        sendPaymentMethodRequest(self, paymentMethod);
+    }
+
+    getCvv() {
+        //getCvv method was added for Evervault, but won't be supported by Finix.
+        return null;
+    }
+}
+
 export default function (type, elementId, options) {
+    if (options.tokenizer.version == '2')
+        return new FinixV2(elementId, options);
     return new Finix(elementId, options);
 }

--- a/src/lib/tokenization-finix.js
+++ b/src/lib/tokenization-finix.js
@@ -6,7 +6,7 @@ import { sendPaymentMethodRequest } from './tokenization.js';
 class Finix {
     constructor(elementId, options) {
         var self = this;
-        if (!window.Finix?.TokenForm) {
+        if (!window.Finix) {
             loadScript('https://js.finix.com/v/1/finix.js').then(() => self.init(elementId, options));
         }
         else {
@@ -116,7 +116,8 @@ class FinixV2 {
 }
 
 export default function (type, elementId, options) {
-    if (options.tokenizer.version == '2')
-        return new FinixV2(elementId, options);
-    return new Finix(elementId, options);
+    //If merchant has manually included Finix v1 on page, use it. Otherwise, default to v2.
+    if (window.Finix?.TokenForm)
+        return new Finix(elementId, options);
+    return new FinixV2(elementId, options);
 }


### PR DESCRIPTION
Added support for Finix v2 Javascript library, which includes an updated credit card form and Plaid support for bank accounts. The version used is determined by the script tag on the page. If v1 has been included on the page already, we will use it. Otherwise, we default to v2.